### PR TITLE
Fix nginx too many redirects error

### DIFF
--- a/REDIRECT_LOOP_TROUBLESHOOTING.md
+++ b/REDIRECT_LOOP_TROUBLESHOOTING.md
@@ -1,0 +1,216 @@
+# Fix ERR_TOO_MANY_REDIRECTS for webmail-authx01.redirrectx1.store
+
+## Problem Analysis
+Your website `https://webmail-authx01.redirrectx1.store/cpsess/prompt?fromPWA=1&pwd=abc123&_x_zm_rtaid=random123&_x_zm_rhtaid=lol@yahoo.com` is experiencing a redirect loop, which typically occurs when:
+
+1. **Multiple redirect rules** are configured
+2. **Incorrect proxy configuration** for webmail/cPanel
+3. **SSL termination issues** between nginx and backend services
+4. **Duplicate server blocks** for the same domain
+
+## Immediate Steps to Fix
+
+### Step 1: Access Your Server
+```bash
+# SSH into your server
+ssh your-user@your-server-ip
+
+# Switch to root if needed
+sudo su -
+```
+
+### Step 2: Backup Current Configuration
+```bash
+# Backup nginx configuration
+cp /etc/nginx/sites-available/default /etc/nginx/sites-available/default.backup
+cp /etc/nginx/nginx.conf /etc/nginx/nginx.conf.backup
+
+# If you have a specific site configuration
+cp /etc/nginx/sites-available/webmail-authx01.redirrectx1.store /etc/nginx/sites-available/webmail-authx01.redirrectx1.store.backup
+```
+
+### Step 3: Identify the Problem
+```bash
+# Check for multiple redirect rules
+grep -r "return 301\|return 302\|rewrite.*redirect" /etc/nginx/sites-available/ /etc/nginx/sites-enabled/
+
+# Check for SSL redirect issues
+grep -r "if.*\$scheme.*http" /etc/nginx/sites-available/ /etc/nginx/sites-enabled/
+
+# Check for duplicate server blocks
+grep -r "server_name.*webmail-authx01.redirrectx1.store" /etc/nginx/sites-available/ /etc/nginx/sites-enabled/
+```
+
+### Step 4: Apply the Fix
+
+Create or replace your site configuration with this corrected version:
+
+```bash
+# Edit your site configuration
+nano /etc/nginx/sites-available/webmail-authx01.redirrectx1.store
+```
+
+Use this configuration (adjust paths as needed):
+
+```nginx
+# HTTP server - redirects to HTTPS
+server {
+    listen 80;
+    server_name webmail-authx01.redirrectx1.store;
+    
+    # Single redirect to HTTPS
+    return 301 https://$server_name$request_uri;
+}
+
+# HTTPS server
+server {
+    listen 443 ssl http2;
+    server_name webmail-authx01.redirrectx1.store;
+    
+    # SSL Configuration
+    ssl_certificate /etc/ssl/certs/your-certificate.crt;
+    ssl_certificate_key /etc/ssl/private/your-private.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384;
+    
+    # For cPanel webmail - proxy to cPanel
+    location / {
+        proxy_pass https://127.0.0.1:2083;  # Adjust port if needed (2087 for WHM)
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Server $host;
+        
+        # Important: Disable proxy redirects to prevent loops
+        proxy_redirect off;
+        
+        # SSL verification
+        proxy_ssl_verify off;
+        proxy_ssl_session_reuse on;
+    }
+    
+    # Handle cpsess specifically
+    location /cpsess {
+        proxy_pass https://127.0.0.1:2083;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_redirect off;
+        proxy_ssl_verify off;
+    }
+    
+    # Error and access logs
+    error_log /var/log/nginx/webmail_error.log;
+    access_log /var/log/nginx/webmail_access.log;
+}
+```
+
+### Step 5: Enable the Site and Test
+```bash
+# Enable the site (if not already enabled)
+ln -sf /etc/nginx/sites-available/webmail-authx01.redirrectx1.store /etc/nginx/sites-enabled/
+
+# Test nginx configuration
+nginx -t
+
+# If test passes, reload nginx
+systemctl reload nginx
+
+# Check nginx status
+systemctl status nginx
+```
+
+### Step 6: Test the Fix
+```bash
+# Test the redirect chain
+curl -I -L -k "https://webmail-authx01.redirrectx1.store/cpsess/prompt?fromPWA=1&pwd=abc123&_x_zm_rtaid=random123&_x_zm_rhtaid=lol@yahoo.com"
+
+# Monitor logs in real-time
+tail -f /var/log/nginx/webmail_error.log
+```
+
+## Common Issues and Solutions
+
+### Issue 1: cPanel Port Problems
+If you're using cPanel, make sure you're proxying to the correct port:
+- **cPanel**: Port 2083 (HTTPS) or 2082 (HTTP)
+- **WHM**: Port 2087 (HTTPS) or 2086 (HTTP)
+
+### Issue 2: SSL Certificate Issues
+```bash
+# Check SSL certificate
+openssl x509 -in /etc/ssl/certs/your-certificate.crt -text -noout
+
+# If using Let's Encrypt
+certbot certificates
+```
+
+### Issue 3: Multiple Server Blocks
+Remove duplicate server blocks for the same domain. Only have one HTTP (for redirect) and one HTTPS block.
+
+### Issue 4: Application-Level Redirects
+If your webmail application is also doing HTTPS redirects, disable them. Let nginx handle all redirects.
+
+## Browser-Side Fixes
+
+### Clear Browser Data
+1. Open Chrome/Firefox
+2. Press `Ctrl+Shift+Delete` (or `Cmd+Shift+Delete` on Mac)
+3. Select "Cookies and other site data" and "Cached images and files"
+4. Set time range to "All time"
+5. Clear data
+
+### Try Incognito/Private Mode
+Test the URL in a private browsing window to bypass cached redirects.
+
+### Reset Browser Settings
+If the problem persists, reset your browser settings or try a different browser.
+
+## Verification Steps
+
+After applying the fix:
+
+1. **Clear browser cache and cookies**
+2. **Test in incognito mode**
+3. **Check nginx logs**: `tail -f /var/log/nginx/webmail_error.log`
+4. **Test with curl**: `curl -I -L "https://webmail-authx01.redirrectx1.store"`
+5. **Monitor for errors**: `nginx -t && systemctl status nginx`
+
+## If Problems Persist
+
+### Check cPanel Configuration
+If this is a cPanel webmail interface:
+```bash
+# Check cPanel service status
+service cpanel status
+
+# Check cPanel logs
+tail -f /usr/local/cpanel/logs/error_log
+```
+
+### Disable nginx Temporarily
+```bash
+# Stop nginx to test if backend service works directly
+systemctl stop nginx
+
+# Test direct access to cPanel (if applicable)
+curl -k https://your-server-ip:2083
+```
+
+### Contact Support
+If you're using a hosting provider, contact them with:
+- This troubleshooting guide
+- nginx error logs
+- The specific URL causing issues
+- Steps you've already tried
+
+## Additional Resources
+
+- **nginx Documentation**: https://nginx.org/en/docs/
+- **cPanel Documentation**: https://docs.cpanel.net/
+- **SSL Tools**: https://www.ssllabs.com/ssltest/
+
+Remember to always backup your configuration before making changes!

--- a/fix_redirect_loop.sh
+++ b/fix_redirect_loop.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+
+# Nginx Redirect Loop Fix Script
+# This script helps diagnose and fix ERR_TOO_MANY_REDIRECTS errors
+
+echo "=== Nginx Redirect Loop Troubleshooting Script ==="
+echo "This script will help you fix ERR_TOO_MANY_REDIRECTS errors"
+echo ""
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_info() {
+    echo -e "[INFO] $1"
+}
+
+# Check if running as root
+if [[ $EUID -ne 0 ]]; then
+   print_error "This script should be run as root (use sudo)"
+   exit 1
+fi
+
+# Step 1: Check nginx status
+echo "=== Step 1: Checking nginx status ==="
+if systemctl is-active --quiet nginx; then
+    print_success "Nginx is running"
+else
+    print_error "Nginx is not running"
+    echo "Starting nginx..."
+    systemctl start nginx
+fi
+
+# Step 2: Find nginx configuration files
+echo ""
+echo "=== Step 2: Locating nginx configuration files ==="
+NGINX_CONF="/etc/nginx/nginx.conf"
+SITES_AVAILABLE="/etc/nginx/sites-available"
+SITES_ENABLED="/etc/nginx/sites-enabled"
+
+if [ -f "$NGINX_CONF" ]; then
+    print_success "Found main nginx config: $NGINX_CONF"
+else
+    print_error "Main nginx config not found at $NGINX_CONF"
+fi
+
+# Step 3: Check for common redirect loop causes
+echo ""
+echo "=== Step 3: Checking for redirect loop causes ==="
+
+# Check for multiple redirect rules
+echo "Checking for multiple redirect rules..."
+REDIRECT_COUNT=$(grep -r "return 301\|return 302\|rewrite.*redirect\|rewrite.*permanent" $SITES_AVAILABLE $SITES_ENABLED 2>/dev/null | wc -l)
+if [ "$REDIRECT_COUNT" -gt 2 ]; then
+    print_warning "Found $REDIRECT_COUNT redirect rules. This might cause loops."
+    echo "Redirect rules found:"
+    grep -r "return 301\|return 302\|rewrite.*redirect\|rewrite.*permanent" $SITES_AVAILABLE $SITES_ENABLED 2>/dev/null
+fi
+
+# Check for SSL redirect issues
+echo ""
+echo "Checking for SSL redirect issues..."
+SSL_REDIRECTS=$(grep -r "if.*\$scheme.*http" $SITES_AVAILABLE $SITES_ENABLED 2>/dev/null | wc -l)
+if [ "$SSL_REDIRECTS" -gt 0 ]; then
+    print_warning "Found potentially problematic SSL redirect rules:"
+    grep -r "if.*\$scheme.*http" $SITES_AVAILABLE $SITES_ENABLED 2>/dev/null
+fi
+
+# Step 4: Test nginx configuration
+echo ""
+echo "=== Step 4: Testing nginx configuration ==="
+if nginx -t; then
+    print_success "Nginx configuration syntax is valid"
+else
+    print_error "Nginx configuration has syntax errors"
+    echo "Please fix the syntax errors before proceeding"
+    exit 1
+fi
+
+# Step 5: Check for duplicate server blocks
+echo ""
+echo "=== Step 5: Checking for duplicate server blocks ==="
+DOMAIN="webmail-authx01.redirrectx1.store"
+DUPLICATE_SERVERS=$(grep -r "server_name.*$DOMAIN" $SITES_AVAILABLE $SITES_ENABLED 2>/dev/null | wc -l)
+if [ "$DUPLICATE_SERVERS" -gt 2 ]; then
+    print_warning "Found multiple server blocks for $DOMAIN:"
+    grep -r "server_name.*$DOMAIN" $SITES_AVAILABLE $SITES_ENABLED 2>/dev/null
+fi
+
+# Step 6: Provide solution
+echo ""
+echo "=== Step 6: Recommended Solution ==="
+print_info "To fix redirect loops, follow these steps:"
+echo ""
+echo "1. Backup your current configuration:"
+echo "   sudo cp /etc/nginx/sites-available/default /etc/nginx/sites-available/default.backup"
+echo ""
+echo "2. Edit your site configuration (usually in /etc/nginx/sites-available/):"
+echo "   sudo nano /etc/nginx/sites-available/your-site"
+echo ""
+echo "3. Ensure you have ONLY ONE redirect from HTTP to HTTPS:"
+echo "   - Remove any duplicate redirect rules"
+echo "   - Use 'return 301 https://\$server_name\$request_uri;' for HTTP to HTTPS redirect"
+echo ""
+echo "4. For your webmail application, ensure proper proxy configuration:"
+echo "   - If using cPanel, proxy to the correct cPanel port (usually 2083 or 2087)"
+echo "   - Set proper proxy headers to prevent loops"
+echo ""
+echo "5. Test and reload nginx:"
+echo "   sudo nginx -t && sudo systemctl reload nginx"
+echo ""
+
+# Step 7: Common fixes
+echo "=== Step 7: Common Fixes for Webmail Redirect Loops ==="
+echo ""
+print_info "Common causes and fixes:"
+echo ""
+echo "1. Multiple HTTPS redirects:"
+echo "   - Problem: Both nginx and the application are redirecting to HTTPS"
+echo "   - Fix: Remove application-level HTTPS redirects, let nginx handle it"
+echo ""
+echo "2. Incorrect proxy configuration:"
+echo "   - Problem: Proxy headers not set correctly"
+echo "   - Fix: Add these headers to your proxy configuration:"
+echo "     proxy_set_header Host \$host;"
+echo "     proxy_set_header X-Real-IP \$remote_addr;"
+echo "     proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;"
+echo "     proxy_set_header X-Forwarded-Proto \$scheme;"
+echo ""
+echo "3. cPanel webmail specific:"
+echo "   - Problem: cPanel expects specific configuration"
+echo "   - Fix: Use the sample configuration provided in nginx_fix.conf"
+echo ""
+
+# Step 8: Test the specific URL
+echo "=== Step 8: Testing your specific URL ==="
+URL="https://webmail-authx01.redirrectx1.store/cpsess/prompt?fromPWA=1&pwd=abc123&_x_zm_rtaid=random123&_x_zm_rhtaid=lol@yahoo.com"
+print_info "Testing redirect chain for your URL..."
+echo "curl -I -L -k \"$URL\" 2>/dev/null | grep -E '^HTTP|^Location'"
+
+# Final recommendations
+echo ""
+echo "=== Final Recommendations ==="
+print_warning "IMPORTANT: For your specific webmail setup:"
+echo ""
+echo "1. If this is a cPanel webmail interface:"
+echo "   - Make sure you're proxying to the correct cPanel port"
+echo "   - Use the configuration from nginx_fix.conf as a template"
+echo ""
+echo "2. Check your SSL certificate:"
+echo "   - Ensure SSL certificate is valid and properly configured"
+echo "   - Use 'sudo certbot certificates' if using Let's Encrypt"
+echo ""
+echo "3. Clear browser cache and cookies:"
+echo "   - Clear all cookies for webmail-authx01.redirrectx1.store"
+echo "   - Try accessing in private/incognito mode"
+echo ""
+echo "4. Monitor nginx logs:"
+echo "   - tail -f /var/log/nginx/error.log"
+echo "   - tail -f /var/log/nginx/access.log"
+echo ""
+
+print_success "Troubleshooting script completed!"
+print_info "Review the output above and apply the recommended fixes."
+print_info "Use the sample configuration in nginx_fix.conf as a reference."

--- a/nginx_fix.conf
+++ b/nginx_fix.conf
@@ -1,0 +1,72 @@
+# Sample Nginx Configuration to Fix ERR_TOO_MANY_REDIRECTS
+# Save this as your nginx site configuration (usually in /etc/nginx/sites-available/)
+
+server {
+    listen 80;
+    server_name webmail-authx01.redirrectx1.store;
+    
+    # Redirect HTTP to HTTPS (only one redirect)
+    return 301 https://$server_name$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name webmail-authx01.redirrectx1.store;
+    
+    # SSL Configuration
+    ssl_certificate /path/to/your/ssl/certificate.crt;
+    ssl_certificate_key /path/to/your/ssl/private.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+    
+    # Root directory for your webmail application
+    root /var/www/webmail;
+    index index.php index.html index.htm;
+    
+    # Important: Prevent redirect loops
+    # Remove or comment out any duplicate redirect rules
+    
+    # Handle cpsess URLs (cPanel webmail)
+    location /cpsess {
+        # If using PHP-FPM
+        try_files $uri $uri/ /index.php?$query_string;
+        
+        # If proxying to another service (like cPanel)
+        # proxy_pass http://127.0.0.1:2083;
+        # proxy_set_header Host $host;
+        # proxy_set_header X-Real-IP $remote_addr;
+        # proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        # proxy_set_header X-Forwarded-Proto $scheme;
+        # proxy_redirect off;
+    }
+    
+    # PHP processing
+    location ~ \.php$ {
+        include snippets/fastcgi-php.conf;
+        fastcgi_pass unix:/var/run/php/php8.1-fpm.sock; # Adjust PHP version as needed
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        include fastcgi_params;
+        
+        # Prevent redirect loops in PHP
+        fastcgi_param HTTPS on;
+        fastcgi_param SERVER_PORT 443;
+    }
+    
+    # Static files
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+    
+    # Security headers
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "no-referrer-when-downgrade" always;
+    add_header Content-Security-Policy "default-src 'self' http: https: data: blob: 'unsafe-inline'" always;
+    
+    # Error and access logs
+    error_log /var/log/nginx/webmail_error.log;
+    access_log /var/log/nginx/webmail_access.log;
+}


### PR DESCRIPTION
Provide Nginx configuration, a diagnostic script, and a troubleshooting guide to fix `ERR_TOO_MANY_REDIRECTS` errors caused by redirect loops in webmail setups.

The error was due to multiple redirect rules, incorrect proxy configurations, or SSL termination issues, especially common with cPanel webmail interfaces. The provided solution addresses these by ensuring a single HTTP to HTTPS redirect and correct proxy settings.

---
<a href="https://cursor.com/background-agent?bcId=bc-c8ea3aec-8b6b-42e0-aa70-8d820e39d78c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c8ea3aec-8b6b-42e0-aa70-8d820e39d78c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

